### PR TITLE
[Fix]: Build Errors on Linux

### DIFF
--- a/TriangulateOBJ.h
+++ b/TriangulateOBJ.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <cmath>
+#include <cfloat>
 #include <map>
 #include <vector>
 #include <iostream>

--- a/out.h
+++ b/out.h
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <sstream>
 #include <iostream>
+#include <sys/stat.h>
 
 #include "cmd.h"
 #include "div.h"


### PR DESCRIPTION
# Fix Linux build failure caused by missing includes

## Description 
### Compiling it on Linux with gcc or clang results in a failure as the compiler cant get teh refrence to teh
### strcut stat which is usually defined in 'sys/stat.h' header file and fixing the include fixes the build issue expirienced

## System Configuratin/Environment
 - gcc (GCC) 16.1.1 20260430
 - clang version 20.1.5 
 - cmake version 4.3.3
 - GNU Make 4.4.1
 - cmake version 4.3.3
 - x86_64


## Build Errors Encountered
```
➜ make
[ 50%] Building CXX object CMakeFiles/TriangulateOBJ.dir/main.cpp.o
In file included from /tmp/TriangulateOBJ-App/out.h:25,
                 from /tmp/TriangulateOBJ-App/main.cpp:24:
/tmp/TriangulateOBJ-App/TriangulateOBJ.h: In function ‘int obj::getBiggestEar(const std::vector<Point>&, const Point&)’:
/tmp/TriangulateOBJ-App/TriangulateOBJ.h:863:32: error: ‘DBL_MIN’ was not declared in this scope
  863 |                 double maxArea(DBL_MIN);
      |                                ^~~~~~~
/tmp/TriangulateOBJ-App/TriangulateOBJ.h:24:1: note: ‘DBL_MIN’ is defined in header ‘<cfloat>’; this is probably fixable by adding ‘#include <cfloat>’
   23 | #include <vector>
  +++ |+#include <cfloat>
   24 | #include <iostream>
/tmp/TriangulateOBJ-App/out.h: In function ‘std::string file_size()’:
/tmp/TriangulateOBJ-App/out.h:113:21: error: aggregate ‘file_size()::stat st’ has incomplete type and cannot be defined
  113 |         struct stat st;
      |                     ^~
/tmp/TriangulateOBJ-App/out.h:115:46: error: invalid use of incomplete type ‘struct file_size()::stat’
  115 |         if( stat(target.string().c_str(), &st) != 0 )
      |                                              ^
/tmp/TriangulateOBJ-App/out.h:113:16: note: forward declaration of ‘struct file_size()::stat’
  113 |         struct stat st;
      |                ^~~~
/tmp/TriangulateOBJ-App/out.h: In function ‘std::string file_extend()’:
/tmp/TriangulateOBJ-App/out.h:123:21: error: aggregate ‘file_extend()::stat stSource’ has incomplete type and cannot be defined
  123 |         struct stat stSource;
      |                     ^~~~~~~~
/tmp/TriangulateOBJ-App/out.h:125:52: error: invalid use of incomplete type ‘struct file_extend()::stat’
  125 |         if( stat(source.string().c_str(), &stSource) != 0 )
      |                                                    ^
/tmp/TriangulateOBJ-App/out.h:123:16: note: forward declaration of ‘struct file_extend()::stat’
  123 |         struct stat stSource;
      |                ^~~~
/tmp/TriangulateOBJ-App/out.h:128:21: error: aggregate ‘file_extend()::stat stTarget’ has incomplete type and cannot be defined
  128 |         struct stat stTarget;
      |                     ^~~~~~~~
/tmp/TriangulateOBJ-App/out.h:130:52: error: invalid use of incomplete type ‘struct file_extend()::stat’
  130 |         if( stat(target.string().c_str(), &stTarget) != 0 )
      |                                                    ^
/tmp/TriangulateOBJ-App/out.h:123:16: note: forward declaration of ‘struct file_extend()::stat’
  123 |         struct stat stSource;
      |                ^~~~
make[2]: *** [CMakeFiles/TriangulateOBJ.dir/build.make:79: CMakeFiles/TriangulateOBJ.dir/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/TriangulateOBJ.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

## Primary Issues Observed
- DBL_MIN was not declared in this scope
- 'stat st' has incomplete type and cannot be defined
- invalid use of incomplete type 'struct stat'

## Changes
- Added #include <cfloat> to TriangulateOBJ.h
- Added #include <sys/stat.h> to out.h

## Testing
### Tested on Linux using GCC/Clang/Zig C++ (for windows)
### The project failed to compile before these changes and builds successfully afterward.
